### PR TITLE
Handle PyPDF2 vs pypdf import

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Split a multi-page PDF into named one-page PDFs that sum to the original.
 
 ## Requirements
 - Python 3
-- [PyPDF2](https://pypi.org/project/PyPDF2/)
+- [pypdf](https://pypi.org/project/pypdf/) (the modern fork of PyPDF2)
 
 Install the dependency:
 
 ```bash
-pip install PyPDF2
+pip install pypdf
 ```
 
 ## Usage

--- a/split_pdf.py
+++ b/split_pdf.py
@@ -7,7 +7,10 @@ Usage:
 """
 from pathlib import Path
 import argparse
-from PyPDF2 import PdfReader, PdfWriter
+try:
+    from PyPDF2 import PdfReader, PdfWriter
+except ModuleNotFoundError:  # PyPDF2 is the old package name
+    from pypdf import PdfReader, PdfWriter
 
 
 def split_pdf(pdf_path: Path, output_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- gracefully import from PyPDF2 or pypdf
- document modern pypdf dependency

## Testing
- `python -m py_compile split_pdf.py`
- `python split_pdf.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b8d8bbf8fc832da326761ae955e12f